### PR TITLE
Update MappedArrays compat to include 0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterMismatch"
 uuid = "3c0dd727-6833-5f5d-a1e8-c0d421935c74"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -17,7 +17,7 @@ RegisterMismatchCommon = "abb2e897-52bf-5d28-a379-6ca321e3b878"
 [compat]
 FFTW = "0.3, 1"
 ImageCore = "0.8.1"
-MappedArrays = "0.2, 0.3"
+MappedArrays = "0.2, 0.3, 0.4"
 PaddedViews = "0.5"
 RFFT = "0.1"
 Reexport = "0.2"


### PR DESCRIPTION
This PR updates the MappedArrays compat bounds to include 0.4. This PR also bumps this package's version so that the new compat bounds are released.