### PR TITLE
Support multithreading

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.1'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterMismatch"
 uuid = "3c0dd727-6833-5f5d-a1e8-c0d421935c74"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -23,7 +23,7 @@ RFFT = "0.1"
 Reexport = "0.2, 1"
 RegisterCore = "0.2.1"
 RegisterMismatchCommon = "0.2.2"
-julia = "1.1"
+julia = "1.6"
 
 [extras]
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"

--- a/src/RegisterMismatch.jl
+++ b/src/RegisterMismatch.jl
@@ -147,16 +147,17 @@ function mismatch!(mm::MismatchArray, cms::CMStorage, moving::AbstractArray; nor
     tnum   = complex(cms.buf1)
     tdenom = complex(cms.buf2)
     if normalization == :intensity
-        for i = 1:length(tnum)
+        @inbounds Threads.@threads for i = 1:length(tnum)
             c = 2*conj(f1[i])*m1[i]
             q = conj(f2[i])*m0[i] + conj(f0[i])*m2[i]
             tdenom[i] = q
             tnum[i] = q - c
         end
     elseif normalization == :pixels
-        for i = 1:length(tnum)
-            tdenom[i] = conj(f0[i])*m0[i]
-            tnum[i] = conj(f2[i])*m0[i] - 2*conj(f1[i])*m1[i] + conj(f0[i])*m2[i]
+        @inbounds Threads.@threads for i = 1:length(tnum)
+            f0i, m0i = f0[i], m0[i]
+            tdenom[i] = conj(f0i)*m0i
+            tnum[i] = conj(f2[i])*m0i - 2*conj(f1[i])*m1[i] + conj(f0i)*m2[i]
         end
     else
         error("normalization $normalization not recognized")
@@ -247,7 +248,7 @@ function fftnan!(out::NanCorrFFTs{T}, A::AbstractArray{T}, fftfunc!::Function) w
 end
 
 function _fftnan!(I0, I1, I2, A::AbstractArray{T}) where T<:Real
-    @inbounds for i in CartesianIndices(size(A))
+    @inbounds Threads.@threads for i in CartesianIndices(size(A))
         a = A[i]
         f = !isnan(a)
         I0[i] = f


### PR DESCRIPTION
This requires at least Julia 1.3, but we might as well jump to 1.6.

CC @jona125 (this can speed up the computation of mismatch)