### PR TITLE
Add Manifest-v*.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 deps/deps.jl
 Manifest.toml
+Manifest-v*.toml


### PR DESCRIPTION
## Summary
- Adds `Manifest-v*.toml` glob to `.gitignore` to exclude versioned manifest files from the repository.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)