### PR TITLE
Apply runic formatting

### DIFF
--- a/src/RegisterMismatch.jl
+++ b/src/RegisterMismatch.jl
@@ -62,9 +62,9 @@ The major types and functions exported are:
 RegisterMismatch
 
 FFTW.set_num_threads(min(Sys.CPU_THREADS, 8))
-set_FFTPROD([2,3])
+set_FFTPROD([2, 3])
 
-mutable struct NanCorrFFTs{T<:AbstractFloat,N,RCType<:RCpair{T,N}}
+mutable struct NanCorrFFTs{T <: AbstractFloat, N, RCType <: RCpair{T, N}}
     I0::RCType
     I1::RCType
     I2::RCType
@@ -79,13 +79,13 @@ Prepare for FFT-based mismatch computations over domains of size `aperture_width
 mismatch up to shifts of size `maxshift`.  The keyword arguments allow you to control the planning
 process for the FFTs.
 """
-mutable struct CMStorage{T<:AbstractFloat,N,RCType<:RCpair{T,N},FFT<:Function,IFFT<:Function}
+mutable struct CMStorage{T <: AbstractFloat, N, RCType <: RCpair{T, N}, FFT <: Function, IFFT <: Function}
     aperture_width::Vector{Float64}
     maxshift::Vector{Int}
     getindices::Vector{UnitRange{Int}}   # indices for pulling padded data, in source-coordinates
-    padded::Array{T,N}
-    fixed::NanCorrFFTs{T,N,RCType}
-    moving::NanCorrFFTs{T,N,RCType}
+    padded::Array{T, N}
+    fixed::NanCorrFFTs{T, N, RCType}
+    moving::NanCorrFFTs{T, N, RCType}
     buf1::RCType
     buf2::RCType
     # the next two store the result of calling plan_fft! and plan_ifft!
@@ -94,14 +94,14 @@ mutable struct CMStorage{T<:AbstractFloat,N,RCType<:RCpair{T,N},FFT<:Function,IF
     shiftindices::Vector{Vector{Int}} # indices for performing fftshift & snipping from -maxshift:maxshift
 end
 
-function CMStorage{T,N}(::UndefInitializer, aperture_width::NTuple{N,<:Real}, maxshift::Dims{N}; flags=FFTW.ESTIMATE, timelimit=Inf, display=true) where {T,N}
-    blocksize = map(x->ceil(Int,x), aperture_width)
+function CMStorage{T, N}(::UndefInitializer, aperture_width::NTuple{N, <:Real}, maxshift::Dims{N}; flags = FFTW.ESTIMATE, timelimit = Inf, display = true) where {T, N}
+    blocksize = map(x -> ceil(Int, x), aperture_width)
     padsz = padsize(blocksize, maxshift)
     padded = Array{T}(undef, padsz)
     getindices = padranges(blocksize, maxshift)
     maxshiftv = [maxshift...]
     region = findall(maxshiftv .> 0)
-    fixed  = NanCorrFFTs(RCpair{T}(undef, padsz, region), RCpair{T}(undef, padsz, region), RCpair{T}(undef, padsz, region))
+    fixed = NanCorrFFTs(RCpair{T}(undef, padsz, region), RCpair{T}(undef, padsz, region), RCpair{T}(undef, padsz, region))
     moving = NanCorrFFTs(RCpair{T}(undef, padsz, region), RCpair{T}(undef, padsz, region), RCpair{T}(undef, padsz, region))
     buf1 = RCpair{T}(undef, padsz, region)
     buf2 = RCpair{T}(undef, padsz, region)
@@ -111,21 +111,21 @@ function CMStorage{T,N}(::UndefInitializer, aperture_width::NTuple{N,<:Real}, ma
         flush(stdout)
         tcalib = time()
     end
-    fftfunc = plan_rfft!(fixed.I0, flags=flags, timelimit=timelimit/2)
-    ifftfunc = plan_irfft!(fixed.I0, flags=flags, timelimit=timelimit/2)
+    fftfunc = plan_rfft!(fixed.I0, flags = flags, timelimit = timelimit / 2)
+    ifftfunc = plan_irfft!(fixed.I0, flags = flags, timelimit = timelimit / 2)
     if display && flags != FFTW.ESTIMATE
-        dt = time()-tcalib
+        dt = time() - tcalib
         @printf("done (%.2f seconds)\n", dt)
     end
-    shiftindices = Vector{Int}[ [size(padded,i).+(-maxshift[i]+1:0); 1:maxshift[i]+1] for i = 1:length(maxshift) ]
-    CMStorage{T,N,typeof(buf1),typeof(fftfunc),typeof(ifftfunc)}(Float64[aperture_width...], maxshiftv, getindices, padded, fixed, moving, buf1, buf2, fftfunc, ifftfunc, shiftindices)
+    shiftindices = Vector{Int}[ [size(padded, i) .+ ((-maxshift[i] + 1):0); 1:(maxshift[i] + 1)] for i in 1:length(maxshift) ]
+    return CMStorage{T, N, typeof(buf1), typeof(fftfunc), typeof(ifftfunc)}(Float64[aperture_width...], maxshiftv, getindices, padded, fixed, moving, buf1, buf2, fftfunc, ifftfunc, shiftindices)
 end
 
-CMStorage{T}(::UndefInitializer, aperture_width::NTuple{N,<:Real}, maxshift::Dims{N}; kwargs...) where {T<:Real,N} =
-    CMStorage{T,N}(undef, aperture_width, maxshift; kwargs...)
+CMStorage{T}(::UndefInitializer, aperture_width::NTuple{N, <:Real}, maxshift::Dims{N}; kwargs...) where {T <: Real, N} =
+    CMStorage{T, N}(undef, aperture_width, maxshift; kwargs...)
 
-eltype(cms::CMStorage{T,N}) where {T,N} = T
- ndims(cms::CMStorage{T,N}) where {T,N} = N
+eltype(cms::CMStorage{T, N}) where {T, N} = T
+ndims(cms::CMStorage{T, N}) where {T, N} = N
 
 """
     mm = mismatch([T], fixed, moving, maxshift; normalization=:intensity)
@@ -139,14 +139,14 @@ normalization scheme (`:intensity` or `:pixels`).
 `fixed` and `moving` must have the same size; you can pad with
 `NaN`s as needed. See `nanpad`.
 """
-function mismatch(::Type{T}, fixed::AbstractArray, moving::AbstractArray, maxshift::DimsLike; normalization = :intensity) where T<:Real
+function mismatch(::Type{T}, fixed::AbstractArray, moving::AbstractArray, maxshift::DimsLike; normalization = :intensity) where {T <: Real}
     msz = 2 .* maxshift .+ 1
     mm = MismatchArray(T, msz...)
     cms = CMStorage{T}(undef, size(fixed), maxshift)
     fillfixed!(cms, fixed)
     erng = shiftrange.((cms.getindices...,), first.(axes(fixed)) .- 1)  # expanded rng
     mpad = PaddedView(convert(T, NaN), of_eltype(T, moving), erng)
-    mismatch!(mm, cms, mpad, normalization=normalization)
+    mismatch!(mm, cms, mpad, normalization = normalization)
     return mm
 end
 
@@ -170,20 +170,20 @@ function mismatch!(mm::MismatchArray, cms::CMStorage, moving::AbstractArray; nor
     m0 = complex(cms.moving.I0)
     m1 = complex(cms.moving.I1)
     m2 = complex(cms.moving.I2)
-    tnum   = complex(cms.buf1)
+    tnum = complex(cms.buf1)
     tdenom = complex(cms.buf2)
     if normalization == :intensity
         @inbounds @maybe_threads for i in eachindex(tnum)
-            c = 2*conj(f1[i])*m1[i]
-            q = conj(f2[i])*m0[i] + conj(f0[i])*m2[i]
+            c = 2 * conj(f1[i]) * m1[i]
+            q = conj(f2[i]) * m0[i] + conj(f0[i]) * m2[i]
             tdenom[i] = q
             tnum[i] = q - c
         end
     elseif normalization == :pixels
         @inbounds @maybe_threads for i in eachindex(tnum)
             f0i, m0i = f0[i], m0[i]
-            tdenom[i] = conj(f0i)*m0i
-            tnum[i] = conj(f2[i])*m0i - 2*conj(f1[i])*m1[i] + conj(f0i)*m2[i]
+            tdenom[i] = conj(f0i) * m0i
+            tnum[i] = conj(f2[i]) * m0i - 2 * conj(f1[i]) * m1[i] + conj(f0i) * m2[i]
         end
     else
         error("normalization $normalization not recognized")
@@ -191,7 +191,7 @@ function mismatch!(mm::MismatchArray, cms::CMStorage, moving::AbstractArray; nor
     cms.ifftfunc!(cms.buf1)
     cms.ifftfunc!(cms.buf2)
     copyto!(mm, (view(real(cms.buf1), cms.shiftindices...), view(real(cms.buf2), cms.shiftindices...)))
-    mm
+    return mm
 end
 
 """
@@ -219,20 +219,22 @@ in a rectangular grid, you can use an `N`-dimensional array-of-tuples
 (or array-of-vectors) or an `N+1`-dimensional array with the center
 positions specified along the first dimension. See `aperture_grid`.
 """
-function mismatch_apertures(::Type{T},
-                            fixed::AbstractArray,
-                            moving::AbstractArray,
-                            aperture_centers::AbstractArray,
-                            aperture_width::WidthLike,
-                            maxshift::DimsLike;
-                            normalization = :pixels,
-                            flags = FFTW.MEASURE,
-                            kwargs...) where T
+function mismatch_apertures(
+        ::Type{T},
+        fixed::AbstractArray,
+        moving::AbstractArray,
+        aperture_centers::AbstractArray,
+        aperture_width::WidthLike,
+        maxshift::DimsLike;
+        normalization = :pixels,
+        flags = FFTW.MEASURE,
+        kwargs...
+    ) where {T}
     nd = sdims(fixed)
     (length(aperture_width) == nd && length(maxshift) == nd) || error("Dimensionality mismatch")
     mms = allocate_mmarrays(T, aperture_centers, maxshift)
-    cms = CMStorage{T}(undef, aperture_width, maxshift; flags=flags, kwargs...)
-    mismatch_apertures!(mms, fixed, moving, aperture_centers, cms, normalization=normalization)
+    cms = CMStorage{T}(undef, aperture_width, maxshift; flags = flags, kwargs...)
+    return mismatch_apertures!(mms, fixed, moving, aperture_centers, cms, normalization = normalization)
 end
 
 """
@@ -244,25 +246,25 @@ in `cms`, a `CMStorage` object. The results are stored in `mms`, an
 Array-of-MismatchArrays which must have length equal to the number of
 aperture centers.
 """
-function mismatch_apertures!(mms, fixed, moving, aperture_centers, cms::CMStorage{T}; normalization=:pixels) where T
+function mismatch_apertures!(mms, fixed, moving, aperture_centers, cms::CMStorage{T}; normalization = :pixels) where {T}
     N = ndims(cms)
     fillvalue = convert(T, NaN)
-    getinds = (cms.getindices...,)::NTuple{ndims(fixed),UnitRange{Int}}
+    getinds = (cms.getindices...,)::NTuple{ndims(fixed), UnitRange{Int}}
     fixedT, movingT = of_eltype(T, fixed), of_eltype(T, moving)
-    for (mm,center) in zip(mms, each_point(aperture_centers))
+    for (mm, center) in zip(mms, each_point(aperture_centers))
         rng = aperture_range(center, cms.aperture_width)
         fsnip = PaddedView(fillvalue, fixedT, rng)
         erng = shiftrange.(getinds, first.(rng) .- 1)  # expanded rng
         msnip = PaddedView(fillvalue, movingT, erng)
         # Perform the calculation
         fillfixed!(cms, fsnip)
-        mismatch!(mm, cms, msnip; normalization=normalization)
+        mismatch!(mm, cms, msnip; normalization = normalization)
     end
-    mms
+    return mms
 end
 
 # Calculate the components needed to "nancorrelate"
-function fftnan!(out::NanCorrFFTs{T}, A::AbstractArray{T}, fftfunc!::Function) where T<:Real
+function fftnan!(out::NanCorrFFTs{T}, A::AbstractArray{T}, fftfunc!::Function) where {T <: Real}
     I0 = real(out.I0)
     I1 = real(out.I1)
     I2 = real(out.I2)
@@ -270,25 +272,25 @@ function fftnan!(out::NanCorrFFTs{T}, A::AbstractArray{T}, fftfunc!::Function) w
     fftfunc!(out.I0)
     fftfunc!(out.I1)
     fftfunc!(out.I2)
-    out
+    return out
 end
 
-function _fftnan!(I0, I1, I2, A::AbstractArray{T}) where T<:Real
-    @inbounds @maybe_threads for i in CartesianIndices(size(A))
+function _fftnan!(I0, I1, I2, A::AbstractArray{T}) where {T <: Real}
+    return @inbounds @maybe_threads for i in CartesianIndices(size(A))
         a = A[i]
         f = !isnan(a)
         I0[i] = f
         af = f ? a : zero(T)
         I1[i] = af
-        I2[i] = af*af
+        I2[i] = af * af
     end
 end
 
-function fillfixed!(cms::CMStorage{T}, fixed::AbstractArray) where T
+function fillfixed!(cms::CMStorage{T}, fixed::AbstractArray) where {T}
     fill!(cms.padded, NaN)
-    pinds = CartesianIndices(ntuple(d->(1:size(fixed,d)).+cms.maxshift[d], ndims(fixed)))
+    pinds = CartesianIndices(ntuple(d -> (1:size(fixed, d)) .+ cms.maxshift[d], ndims(fixed)))
     copyto!(cms.padded, pinds, fixed, CartesianIndices(fixed))
-    fftnan!(cms.fixed, cms.padded, cms.fftfunc!)
+    return fftnan!(cms.fixed, cms.padded, cms.fftfunc!)
 end
 
 #### Utilities
@@ -298,23 +300,23 @@ function sumsq_finite(A)
     s = 0.0
     for a in A
         if isfinite(a)
-            s += a*a
+            s += a * a
         end
     end
     if s == 0
         error("No finite values available")
     end
-    s
+    return s
 end
 
 ### Deprecations
 
-function CMStorage{T}(::UndefInitializer, aperture_width::WidthLike, maxshift::WidthLike; kwargs...) where {T<:Real}
+function CMStorage{T}(::UndefInitializer, aperture_width::WidthLike, maxshift::WidthLike; kwargs...) where {T <: Real}
     Base.depwarn("CMStorage with aperture_width::$(typeof(aperture_width)) and maxshift::$(typeof(maxshift)) is deprecated, use tuples instead", :CMStorage)
     (N = length(aperture_width)) == length(maxshift) || error("Dimensionality mismatch")
-    return CMStorage{T,N}(undef, (aperture_width...,), (maxshift...,); kwargs...)
+    return CMStorage{T, N}(undef, (aperture_width...,), (maxshift...,); kwargs...)
 end
 
-@deprecate CMStorage(::Type{T}, aperture_width, maxshift; kwargs...) where T   CMStorage{T}(undef, aperture_width, maxshift; kwargs...)
+@deprecate CMStorage(::Type{T}, aperture_width, maxshift; kwargs...) where {T}   CMStorage{T}(undef, aperture_width, maxshift; kwargs...)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,20 +22,22 @@ let
         global RMlist = (RegisterMismatch,)
     end
 end
-accuracy = 1e-5 # new isapprox accuracy = 1e-6
+accuracy = 1.0e-5 # new isapprox accuracy = 1e-6
 
 # Iterators
 @testset "Iterators" begin
-    agrid = [(1,1)  (1,3)  (1,5)  (1,7);
-             (4,1)  (4,3)  (4,5)  (4,7);
-             (7,1)  (7,3)  (7,5)  (7,7);
-             (10,1) (10,3) (10,5) (10,7)]
-    @test RegisterMismatch.aperture_grid((10,7), (4,4)) == agrid
-    for (i,pt) in enumerate(RegisterMismatch.each_point(agrid))
+    agrid = [
+        (1, 1)  (1, 3)  (1, 5)  (1, 7);
+        (4, 1)  (4, 3)  (4, 5)  (4, 7);
+        (7, 1)  (7, 3)  (7, 5)  (7, 7);
+        (10, 1) (10, 3) (10, 5) (10, 7)
+    ]
+    @test RegisterMismatch.aperture_grid((10, 7), (4, 4)) == agrid
+    for (i, pt) in enumerate(RegisterMismatch.each_point(agrid))
         @test pt == agrid[i]
     end
-    agrida = reshape(reinterpret(Int, vec(agrid)), (2,4,4))
-    for (i,pt) in enumerate(RegisterMismatch.each_point(agrida))
+    agrida = reshape(reinterpret(Int, vec(agrid)), (2, 4, 4))
+    for (i, pt) in enumerate(RegisterMismatch.each_point(agrida))
         @test pt == [agrid[i]...]
     end
 
@@ -44,12 +46,12 @@ end
 
 # Bias correction
 @testset "Bias correction" begin
-    val = NumDenom(2.0,0.5)
+    val = NumDenom(2.0, 0.5)
     # 2d
     mma = fill(val, 3, 3)
-    for i = 1:3
-        mma[2,i] = NumDenom(rand(),rand())
-        mma[i,2] = NumDenom(rand(),rand())
+    for i in 1:3
+        mma[2, i] = NumDenom(rand(), rand())
+        mma[i, 2] = NumDenom(rand(), rand())
     end
     mm = CenterIndexedArray(mma)
     RegisterMismatch.correctbias!(mm)
@@ -60,9 +62,9 @@ end
     end
     # 3d
     mma = fill(val, 3, 3, 3)
-    for i = 1:3, j = 1:3
-        mma[2,i,j] = NumDenom(rand(),rand())
-        mma[i,2,j] = NumDenom(rand(),rand())
+    for i in 1:3, j in 1:3
+        mma[2, i, j] = NumDenom(rand(), rand())
+        mma[i, 2, j] = NumDenom(rand(), rand())
     end
     mm = CenterIndexedArray(mma)
     RegisterMismatch.correctbias!(mm)
@@ -84,22 +86,22 @@ end
                 Bpad = parent(ImageFiltering.padarray(rand(1:20, imsz[1], imsz[2]), Fill(0, maxshift, maxshift)))
                 for RM in RMlist
                     # intensity normalization
-                    mm = RM.mismatch(Apad, Bpad, maxshift, normalization=:intensity)
+                    mm = RM.mismatch(Apad, Bpad, maxshift, normalization = :intensity)
                     num, denom = RegisterCore.separate(mm)
                     mmref = CenterIndexedArray{Float64}(undef, (2 .* maxshift .+ 1)...)
-                    for j = -maxshift[2]:maxshift[2], i = -maxshift[1]:maxshift[1]
+                    for j in -maxshift[2]:maxshift[2], i in -maxshift[1]:maxshift[1]
                         Bshift = circshift(Bpad, -[i, j])
                         df = Apad - Bshift
                         mmref[i, j] = sum(df .^ 2)
                     end
                     nrm = sum(Apad .^ 2) + sum(Bpad .^ 2)
-                    @test ≈(mmref.data, num.data, atol=accuracy * nrm)
-                    @test ≈(fill(nrm, size(denom)), denom.data, atol=accuracy * nrm)
+                    @test ≈(mmref.data, num.data, atol = accuracy * nrm)
+                    @test ≈(fill(nrm, size(denom)), denom.data, atol = accuracy * nrm)
                     # pixel normalization
-                    mm = RM.mismatch(Apad, Bpad, maxshift, normalization=:pixels)
+                    mm = RM.mismatch(Apad, Bpad, maxshift, normalization = :pixels)
                     _, denom = RegisterCore.separate(mm)
-                    n = Vector{Int}[size(Apad, i) .- abs.(-maxshift[i]:maxshift[i]) for i = 1:2]
-                    @test ≈(denom.data, n[1] .* n[2]', atol=accuracy * maximum(denom))
+                    n = Vector{Int}[size(Apad, i) .- abs.(-maxshift[i]:maxshift[i]) for i in 1:2]
+                    @test ≈(denom.data, n[1] .* n[2]', atol = accuracy * maximum(denom))
                 end
             end
         end
@@ -112,25 +114,25 @@ end
     D16 = N0f16[0.7 0.1; 0.6 0.1]
     C = Float64.(C16)
     D = Float64.(D16)
-    nd = RegisterMismatch.mismatch0(C16, D16; normalization=:intensity)
-    @test nd.denom ≈ sum((C.^2).+(D.^2))
-    @test nd.num ≈ sum((C.-D).^2)
+    nd = RegisterMismatch.mismatch0(C16, D16; normalization = :intensity)
+    @test nd.denom ≈ sum((C .^ 2) .+ (D .^ 2))
+    @test nd.num ≈ sum((C .- D) .^ 2)
 end
 
 # Compare direct, global, and apertured
 @testset "Compare direct, global and apertured" begin
-    C = rand(7,9)
-    D = rand(7,9)
-    mm = RegisterMismatch.mismatch(C, D, (3,3))
+    C = rand(7, 9)
+    D = rand(7, 9)
+    mm = RegisterMismatch.mismatch(C, D, (3, 3))
     nd = RegisterMismatch.mismatch0(C, D)
-    @test mm[0,0].num ≈ nd.num
-    @test mm[0,0].denom ≈ nd.denom
-    mm = RegisterMismatch.mismatch(C, D, (3,3), normalization=:pixels)
-    nd = RegisterMismatch.mismatch0(C, D, normalization=:pixels)
-    @test mm[0,0].num ≈ nd.num
-    @test mm[0,0].denom ≈ nd.denom
+    @test mm[0, 0].num ≈ nd.num
+    @test mm[0, 0].denom ≈ nd.denom
+    mm = RegisterMismatch.mismatch(C, D, (3, 3), normalization = :pixels)
+    nd = RegisterMismatch.mismatch0(C, D, normalization = :pixels)
+    @test mm[0, 0].num ≈ nd.num
+    @test mm[0, 0].denom ≈ nd.denom
 
-    mms = RegisterMismatch.mismatch_apertures(C, D, (2,2), (3,2), normalization=:intensity)
+    mms = RegisterMismatch.mismatch_apertures(C, D, (2, 2), (3, 2), normalization = :intensity)
     nd0 = RegisterMismatch.mismatch0(C, D)
     nd1 = RegisterMismatch.mismatch0(mms)
     @test nd0.num ≈ nd1.num
@@ -142,32 +144,32 @@ end
 #     sum(nums) == num
 # where num is equivalent to what would be computed globally (using mismatch)
 @testset "Block mismatch" begin
-    for imsz in ((15,16), (14,17))
-        for maxshift in ((4,3), (3,2))
-            for gridsize in ((2,1), (2,3), (2,2), (1,3))
+    for imsz in ((15, 16), (14, 17))
+        for maxshift in ((4, 3), (3, 2))
+            for gridsize in ((2, 1), (2, 3), (2, 2), (1, 3))
                 Apad = parent(ImageFiltering.padarray(reshape(1:prod(imsz), imsz[1], imsz[2]), Fill(0, maxshift, maxshift)))
                 Bpad = parent(ImageFiltering.padarray(rand(1:20, imsz[1], imsz[2]), Fill(0, maxshift, maxshift)))
                 for RM in RMlist
                     # intensity normalization
-                    mms = RM.mismatch_apertures(Float64, Apad, Bpad, gridsize, maxshift, normalization=:intensity, display=false)
+                    mms = RM.mismatch_apertures(Float64, Apad, Bpad, gridsize, maxshift, normalization = :intensity, display = false)
                     nums, denoms = RegisterCore.separate(mms)
                     num = sum(nums)
                     denom = sum(denoms)
                     mm = CenterIndexedArray{Float64}(undef, (2 .* maxshift .+ 1)...)
-                    for j = -maxshift[2]:maxshift[2], i = -maxshift[1]:maxshift[1]
-                        Bshift = circshift(Bpad,-[i,j])
-                        df = Apad-Bshift
-                        mm[i,j] = sum(df.^2)
+                    for j in -maxshift[2]:maxshift[2], i in -maxshift[1]:maxshift[1]
+                        Bshift = circshift(Bpad, -[i, j])
+                        df = Apad - Bshift
+                        mm[i, j] = sum(df .^ 2)
                     end
-                    nrm = sum(Apad.^2)+sum(Bpad.^2)
-                    @test ≈(mm.data, num.data, atol=accuracy*nrm)
-                    @test ≈(fill(nrm,size(denom)), denom.data, atol=accuracy*nrm)
+                    nrm = sum(Apad .^ 2) + sum(Bpad .^ 2)
+                    @test ≈(mm.data, num.data, atol = accuracy * nrm)
+                    @test ≈(fill(nrm, size(denom)), denom.data, atol = accuracy * nrm)
                     # pixel normalization
-                    mms = RM.mismatch_apertures(Float64, Apad, Bpad, gridsize, maxshift, normalization=:pixels, display=false)
+                    mms = RM.mismatch_apertures(Float64, Apad, Bpad, gridsize, maxshift, normalization = :pixels, display = false)
                     _, denoms = RegisterCore.separate(mms)
                     denom = sum(denoms)
-                    n = Vector{Int}[size(Apad,i).-abs.(-maxshift[i]:maxshift[i]) for i = 1:2]
-                    @test ≈(denom.data, n[1].*n[2]', atol=accuracy*maximum(denom))
+                    n = Vector{Int}[size(Apad, i) .- abs.(-maxshift[i]:maxshift[i]) for i in 1:2]
+                    @test ≈(denom.data, n[1] .* n[2]', atol = accuracy * maximum(denom))
                 end
             end
         end
@@ -175,26 +177,26 @@ end
 
     for RM in RMlist
         # Test 3d similarly
-        Apad = parent(ImageFiltering.padarray(reshape(1:80*6, 10, 8, 6), Fill(0, (4,3,2))))
-        Bpad = parent(ImageFiltering.padarray(rand(1:80*6, 10, 8, 6), Fill(0, (4,3,2))))
-        mm = RM.mismatch(Apad, Bpad, (4,3,2))
+        Apad = parent(ImageFiltering.padarray(reshape(1:(80 * 6), 10, 8, 6), Fill(0, (4, 3, 2))))
+        Bpad = parent(ImageFiltering.padarray(rand(1:(80 * 6), 10, 8, 6), Fill(0, (4, 3, 2))))
+        mm = RM.mismatch(Apad, Bpad, (4, 3, 2))
         num, denom = RegisterCore.separate(mm)
         mmref = CenterIndexedArray{Float64}(undef, 9, 7, 5)
-        for k=-2:2, j = -3:3, i = -4:4
-            Bshift = circshift(Bpad,-[i,j,k])
-            df = Apad-Bshift
-            mmref[i,j,k] = sum(df.^2)
+        for k in -2:2, j in -3:3, i in -4:4
+            Bshift = circshift(Bpad, -[i, j, k])
+            df = Apad - Bshift
+            mmref[i, j, k] = sum(df .^ 2)
         end
-        nrm = sum(Apad.^2)+sum(Bpad.^2)
-        @test ≈(mmref.data, num.data, atol=accuracy*nrm)
-        @test ≈(fill(nrm,size(denom)), denom.data, atol=accuracy*nrm)
+        nrm = sum(Apad .^ 2) + sum(Bpad .^ 2)
+        @test ≈(mmref.data, num.data, atol = accuracy * nrm)
+        @test ≈(fill(nrm, size(denom)), denom.data, atol = accuracy * nrm)
 
-        mms = RM.mismatch_apertures(Apad, Bpad, (2,3,2), (4,3,2), normalization=:intensity, display=false)
+        mms = RM.mismatch_apertures(Apad, Bpad, (2, 3, 2), (4, 3, 2), normalization = :intensity, display = false)
         nums, denoms = RegisterCore.separate(mms)
         num = sum(nums)
         denom = sum(denoms)
-        @test ≈(mmref.data, num.data, atol=accuracy*nrm)
-        @test ≈(fill(sum(Apad.^2)+sum(Bpad.^2),size(denom)), denom.data, atol=accuracy*nrm)
+        @test ≈(mmref.data, num.data, atol = accuracy * nrm)
+        @test ≈(fill(sum(Apad .^ 2) + sum(Bpad .^ 2), size(denom)), denom.data, atol = accuracy * nrm)
     end
 end
 
@@ -203,38 +205,38 @@ end
 @testset "Utility functions" begin
     RM = RegisterMismatch
     A = fill(7, 8, 4)
-    Ahp = RM.highpass(Float32, A, (1,1))
+    Ahp = RM.highpass(Float32, A, (1, 1))
     @test eltype(Ahp) == Float32
-    @test maximum(abs.(Ahp)) < 100*eps(Float32)
-    Ahp = RM.highpass(A, (1.2,Inf))
+    @test maximum(abs.(Ahp)) < 100 * eps(Float32)
+    Ahp = RM.highpass(A, (1.2, Inf))
     @test A == Ahp
     A = Float64.(A)
-    A[1,1] = NaN
-    Ahp = RM.highpass(Float32, A, (1,1))
-    @test sum(x->!isfinite(x), Ahp) == 1
-    @test isnan(Ahp[1,1])
-    Ahp[1,1] = 0
-    @test maximum(abs, Ahp) < 3e-6
+    A[1, 1] = NaN
+    Ahp = RM.highpass(Float32, A, (1, 1))
+    @test sum(x -> !isfinite(x), Ahp) == 1
+    @test isnan(Ahp[1, 1])
+    Ahp[1, 1] = 0
+    @test maximum(abs, Ahp) < 3.0e-6
 
 
     num = float([1 2; 3 4])
-    denom = [1 1e-6; 2 1]
+    denom = [1 1.0e-6; 2 1]
     nd = RegisterCore._packnd!(similar(num, RegisterCore.NumDenom{Float64}), num, denom)
-    RM.truncatenoise!(nd, 1e-5)
+    RM.truncatenoise!(nd, 1.0e-5)
     numt, denomt = RegisterCore.separate(nd)
     @test numt == [1 0; 3 4]
     @test denomt == [1 0; 2 1]
 
     outer = reshape(1:120, 12, 10)
-    A = outer[1:10,2:9]
-    B = outer[3:12,1:8]
-    maxshift = (3,11)
-    @test register_translate(A, B, maxshift) == CartesianIndex((-2,1))
+    A = outer[1:10, 2:9]
+    B = outer[3:12, 1:8]
+    maxshift = (3, 11)
+    @test register_translate(A, B, maxshift) == CartesianIndex((-2, 1))
 end
 
 # Mismatched types
 @testset "Mismatched types" begin
-   A = rand(Float32, 5, 5)
+    A = rand(Float32, 5, 5)
     B = rand(5, 5)
     mm = RegisterMismatch.mismatch0(A, B)
     @test eltype(mm) == Float64
@@ -247,10 +249,10 @@ mxshift = (2, 2)
 mm = RegisterMismatch.mismatch(fixed, fullimg, mxshift)
 num, denom = RegisterCore.separate(mm)
 mm = CenterIndexedArray{Float64}(undef, (2 .* mxshift .+ 1)...)
-for j = -mxshift[2]:mxshift[2], i = -mxshift[1]:mxshift[1]
+for j in -mxshift[2]:mxshift[2], i in -mxshift[1]:mxshift[1]
     mshift = OffsetArray(fullimg, (-i, -j))
     idx = intersect.(axes(fixed), axes(mshift))
     fsnip, msnip = fixed[idx...], mshift[idx...]
-    mm[i,j] = sum((fsnip .- msnip).^2) / (sum(fsnip.^2) + sum(msnip.^2))
+    mm[i, j] = sum((fsnip .- msnip) .^ 2) / (sum(fsnip .^ 2) + sum(msnip .^ 2))
 end
 @test num ./ denom ≈ mm


### PR DESCRIPTION
## Summary
- Applies `runic` formatting to `src/` and `test/`
- Formatting-only commit; no functional changes

## Test plan
- [x] Tests pass before formatting
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)