### PR TITLE
Fix docs build errors introduced by 1.0.1 API review

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,7 +19,7 @@ mismatch
 mismatch!
 mismatch_apertures
 mismatch_apertures!
-mismatch0
+mismatch_zeroshift
 ```
 
 ## Low-level reusable workflow
@@ -41,7 +41,9 @@ nanpad
 
 ```@docs
 correctbias!
+correctbias
 truncatenoise!
+truncatenoise
 ```
 
 ## Utilities
@@ -51,8 +53,11 @@ register_translate
 aperture_grid
 allocate_mmarrays
 aperture_range
-each_point
+each_aperture_center
+FFTPROD
 set_FFTPROD
+inner_threading
+set_inner_threading!
 ```
 
 ## Types and helpers (RegisterCore)
@@ -91,8 +96,8 @@ WidthLike
 ## Internal helpers
 
 ```@docs
-assertsamesize
-checksize_maxshift
+checksamesize
+checksizemaxshift
 default_aperture_width
 padranges
 padsize

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -166,7 +166,7 @@ is below a noise threshold.
 ```jldoctest
 julia> mm = mismatch([1.0 2.0; 3.0 4.0], [1.0 2.0; 3.0 4.0], (1, 1));
 
-julia> nd = mismatch0([1.0 2.0; 3.0 4.0], [1.0 2.0; 3.0 4.0])
+julia> nd = mismatch_zeroshift([1.0 2.0; 3.0 4.0], [1.0 2.0; 3.0 4.0])
 NumDenom(0.0,60.0)
 ```
 


### PR DESCRIPTION
## Summary

- **`api.md`**: add 9 exported symbols that gained docstrings in RegisterMismatchCommon 1.0.3 (`mismatch_zeroshift`, `correctbias`, `truncatenoise`, `checksamesize`, `checksizemaxshift`, `each_aperture_center`, `FFTPROD`, `inner_threading`, `set_inner_threading!`); remove 4 `@deprecate`-only aliases that have no Documenter docstrings (`mismatch0`, `each_point`, `assertsamesize`, `checksize_maxshift`).
- **`index.md`**: replace deprecated `mismatch0` with `mismatch_zeroshift` in the Post-processing doctest.

## Test plan

- [ ] Docs CI passes (no `:cross_references`, `:missing_docs`, or `:docs_block` errors)
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)